### PR TITLE
Disable macOS Sierra tab bar (View > Show Tab Bar).

### DIFF
--- a/main/disableWindowTabbing.mm
+++ b/main/disableWindowTabbing.mm
@@ -1,0 +1,14 @@
+// Disable macOS Sierra tab bar (surfaced as: View > Show Tab Bar).
+//
+// Workaround provided by Morten Sorvig <Morten.Sorvig@qt.io>,
+// http://lists.qt-project.org/pipermail/interest/2016-September/024488.html.
+
+#import <AppKit/AppKit.h>
+
+// Disables auto window tabbing where supported, otherwise a no-op.
+void disableWindowTabbing()
+{
+    if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)]) {
+        NSWindow.allowsAutomaticWindowTabbing = NO;
+    }
+}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -27,13 +27,24 @@ extern "C" int staterun(int argc, char *arg1, int arg2)
 
 int main(int argc, char *argv[])
 {
-#if defined(__MACH__) && !defined(QT50)
+#if defined(__MACH__)
+#if !defined(QT50)
   if ( QSysInfo::MacintoshVersion > QSysInfo::MV_10_8 ) {
     // fix Mac OS X 10.9 (mavericks) font issue
     // https://bugreports.qt-project.org/browse/QTBUG-32789
     QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
   }
 #endif
+  if ( QSysInfo::MacintoshVersion > QSysInfo::MV_10_11 ) {
+    // Disable (unsupported) macOS Sierra tab bar functionality.
+    //
+    // Given that this behaviour will likely persist in subsequent releases
+    // of macOS, just check the lower version bound.
+    extern void disableWindowTabbing();
+    disableWindowTabbing();
+  }
+#endif
+
   char *path=jepath1(argv[0]);     // get path to JFE folder
 
   bool fhs = false;

--- a/main/main.pro
+++ b/main/main.pro
@@ -65,6 +65,10 @@ win32:SOURCES += dllsrc/jdllcomx.cpp
 win32:HEADERS += dllsrc/jexe.h dllsrc/jdllcom.h dllsrc/jdlltype.h
 CONFIG+= release
 
+# macOS-specific sources (Objective-C).
+macx:OBJECTIVE_SOURCES += disableWindowTabbing.mm
+macx:LIBS += -framework AppKit
+
 win32:LIBS += -lole32 -loleaut32 -luuid -ladvapi32
 win32-msvc*:DEFINES += _CRT_SECURE_NO_WARNINGS
 win32:!win32-msvc*:QMAKE_LFLAGS += -static-libgcc


### PR DESCRIPTION
Workaround provided by Morten Sorvig <Morten.Sorvig@qt.io>,
http://lists.qt-project.org/pipermail/interest/2016-September/024488.html.